### PR TITLE
borre import from datetime import date, datetime, time

### DIFF
--- a/App/Models.py
+++ b/App/Models.py
@@ -1,6 +1,5 @@
 from sqlalchemy import Integer, String, Boolean, Date, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from datetime import date
 from Database import Base
 
 class Persona(Base):


### PR DESCRIPTION
Ya en la primera linea tenemos lo necesario para modelos. Con Agustin decidimos usar Date y Time (por el horario de los turnos y sus fechas)  de sqlalchemy para definir los modelos,  y por otro lado date y time de datetime en la logica de turnos (punto C).